### PR TITLE
Prevent duplicate qr codes being provided within 5 seconds of first r…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ dependencies {
 
     ...
 
-     implementation 'org.smartregister:android-p2p-sync:0.3.6-SNAPSHOT'
+     implementation 'org.smartregister:android-p2p-sync:0.3.7-SNAPSHOT'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 android.enableUnitTestBinaryResources=true
-VERSION_NAME=0.3.6-SNAPSHOT
+VERSION_NAME=0.3.7-SNAPSHOT
 VERSION_CODE=1
 GROUP=org.smartregister
 POM_SETTING_DESCRIPTION=Android Peer-to-Peer Sync

--- a/p2p-sync/src/main/java/org/smartregister/p2p/fragment/QRCodeScanningFragment.java
+++ b/p2p-sync/src/main/java/org/smartregister/p2p/fragment/QRCodeScanningFragment.java
@@ -64,7 +64,9 @@ public class QRCodeScanningFragment extends Fragment {
         qrCodeScannerView.addOnBarcodeRecognisedListener(new QRCodeScannerView.OnQRRecognisedListener() {
             @Override
             public void onBarcodeRecognised(SparseArray<Barcode> recognisedItems) {
-                if (areCodesDuplicate(recognisedItems)) return;
+                if (areCodesDuplicate(recognisedItems)) {
+                    return;
+                }
 
                 if (qrCodeScanDialogCallback != null) {
                     qrCodeScanDialogCallback.qrCodeScanned(recognisedItems);

--- a/p2p-sync/src/main/java/org/smartregister/p2p/fragment/QRCodeScanningFragment.java
+++ b/p2p-sync/src/main/java/org/smartregister/p2p/fragment/QRCodeScanningFragment.java
@@ -3,6 +3,7 @@ package org.smartregister.p2p.fragment;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.Fragment;
 import android.util.SparseArray;
 import android.view.LayoutInflater;
@@ -63,23 +64,7 @@ public class QRCodeScanningFragment extends Fragment {
         qrCodeScannerView.addOnBarcodeRecognisedListener(new QRCodeScannerView.OnQRRecognisedListener() {
             @Override
             public void onBarcodeRecognised(SparseArray<Barcode> recognisedItems) {
-                long currentTime = System.currentTimeMillis();
-
-                for (int i = 0; i < recognisedItems.size(); i++) {
-                    String scannedCode = recognisedItems.valueAt(i).rawValue;
-                    Long lastTimeRecorded = alreadyReadCodes.get(scannedCode);
-
-                    // Ignore duplicate codes recorded within
-                    if (lastTimeRecorded != null) {
-                        if ((currentTime - lastTimeRecorded) <= CODES_EXPIRE_TIME) {
-                            return;
-                        } else {
-                            alreadyReadCodes.put(scannedCode, currentTime);
-                        }
-                    } else {
-                        alreadyReadCodes.put(scannedCode, currentTime);
-                    }
-                }
+                if (areCodesDuplicate(recognisedItems)) return;
 
                 if (qrCodeScanDialogCallback != null) {
                     qrCodeScanDialogCallback.qrCodeScanned(recognisedItems);
@@ -93,6 +78,29 @@ public class QRCodeScanningFragment extends Fragment {
         scanningInstructions.setText(String.format(getString(R.string.qr_code_scanning_dialog_message), deviceName));
 
         return view;
+    }
+
+    @VisibleForTesting
+    protected boolean areCodesDuplicate(@NonNull SparseArray<Barcode> recognisedItems) {
+        long currentTime = System.currentTimeMillis();
+
+        for (int i = 0; i < recognisedItems.size(); i++) {
+            String scannedCode = recognisedItems.valueAt(i).rawValue;
+            Long lastTimeRecorded = alreadyReadCodes.get(scannedCode);
+
+            // Ignore duplicate codes recorded within
+            if (lastTimeRecorded != null) {
+                if ((currentTime - lastTimeRecorded) <= CODES_EXPIRE_TIME) {
+                    return true;
+                } else {
+                    alreadyReadCodes.put(scannedCode, currentTime);
+                }
+            } else {
+                alreadyReadCodes.put(scannedCode, currentTime);
+            }
+        }
+
+        return false;
     }
 
     private void closeFragment() {

--- a/p2p-sync/src/test/java/android/util/SparseArray.java
+++ b/p2p-sync/src/test/java/android/util/SparseArray.java
@@ -1,0 +1,115 @@
+package android.util;
+
+import java.util.HashMap;
+
+
+/**
+ * Created by Ephraim Kigamba - nek.eam@gmail.com on 24-07-2020.
+ */
+
+public class SparseArray<E> {
+
+    private HashMap<Integer, E> mHashMap;
+
+    public SparseArray() {
+        mHashMap = new HashMap<>();
+    }
+
+    public void put(int key, E value) {
+        mHashMap.put(key, value);
+    }
+
+    public E get(int key) {
+        return mHashMap.get(key);
+    }
+
+    @SuppressWarnings("unchecked")
+    public E get(int key, E valueIfKeyNotFound) {
+        return mHashMap.getOrDefault(key, valueIfKeyNotFound);
+    }
+
+    public void delete(int key) {
+        mHashMap.remove(key);
+    }
+
+    public E removeReturnOld(int key) {
+        return mHashMap.remove(key);
+    }
+
+    /**
+     * Alias for {@link #delete(int)}.
+     */
+    public void remove(int key) {
+        delete(key);
+    }
+
+    public void removeAt(int index) {
+
+    }
+
+    public void removeAtRange(int index, int size) {
+    }
+
+    public int size() {
+        return mHashMap.size();
+    }
+
+    public int keyAt(int index) {
+        return -1;
+    }
+
+    @SuppressWarnings("unchecked")
+    public E valueAt(int index) {
+        return mHashMap.get(index);
+    }
+
+    public void setValueAt(int index, E value) {
+        mHashMap.put(index, value);
+    }
+
+    public int indexOfKey(int key) {
+        return key;
+    }
+
+    public int indexOfValue(E value) {
+        return -1;
+    }
+
+    public int indexOfValueByValue(E value) {
+        return -1;
+    }
+
+    public void clear() {
+        mHashMap.clear();
+    }
+
+    public void append(int key, E value) {
+        put(key, value);
+    }
+
+    @Override
+    public String toString() {
+        if (size() <= 0) {
+            return "{}";
+        }
+
+        StringBuilder buffer = new StringBuilder(mHashMap.size() * 28);
+        buffer.append('{');
+        for (int i = 0; i< mHashMap.size(); i++) {
+            if (i > 0) {
+                buffer.append(", ");
+            }
+            int key = keyAt(i);
+            buffer.append(key);
+            buffer.append('=');
+            Object value = valueAt(i);
+            if (value != this) {
+                buffer.append(value);
+            } else {
+                buffer.append("(this Map)");
+            }
+        }
+        buffer.append('}');
+        return buffer.toString();
+    }
+}

--- a/p2p-sync/src/test/java/android/util/SparseArray.java
+++ b/p2p-sync/src/test/java/android/util/SparseArray.java
@@ -44,10 +44,11 @@ public class SparseArray<E> {
     }
 
     public void removeAt(int index) {
-
+        // Do nothing for now
     }
 
     public void removeAtRange(int index, int size) {
+        // Do nothing for now
     }
 
     public int size() {

--- a/p2p-sync/src/test/java/org/smartregister/p2p/fragment/QRCodeScanningFragmentTest.java
+++ b/p2p-sync/src/test/java/org/smartregister/p2p/fragment/QRCodeScanningFragmentTest.java
@@ -1,0 +1,67 @@
+package org.smartregister.p2p.fragment;
+
+import android.util.SparseArray;
+
+import com.google.android.gms.vision.barcode.Barcode;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.util.ReflectionHelpers;
+
+import java.util.HashMap;
+
+
+/**
+ * Created by Ephraim Kigamba - nek.eam@gmail.com on 24-07-2020.
+ */
+public class QRCodeScanningFragmentTest {
+
+    private QRCodeScanningFragment qrCodeScanningFragment;
+
+    @Before
+    public void setUp() throws Exception {
+        qrCodeScanningFragment = new QRCodeScanningFragment();
+    }
+
+    @Test
+    public void areCodesDuplicateShouldReturnFalse() {
+        SparseArray<Barcode> scanResults = new SparseArray<>();
+
+        Barcode barcode = new Barcode();
+        barcode.rawValue = "98238";
+        scanResults.append(0 , barcode);
+
+        Assert.assertFalse(qrCodeScanningFragment.areCodesDuplicate(scanResults));
+    }
+
+    @Test
+    public void areCodesDuplicateShouldReturnTrueWhenCodeIsDuplicateWithin5Seconds() {
+        String barcodeResult = "98238";
+        HashMap<String, Long> alreadyReadCodes = ReflectionHelpers.getField(qrCodeScanningFragment, "alreadyReadCodes");
+        alreadyReadCodes.put(barcodeResult, System.currentTimeMillis());
+
+        SparseArray<Barcode> scanResults = new SparseArray<>();
+
+        Barcode barcode = new Barcode();
+        barcode.rawValue = barcodeResult;
+        scanResults.append(0 , barcode);
+
+        Assert.assertTrue(qrCodeScanningFragment.areCodesDuplicate(scanResults));
+    }
+
+    @Test
+    public void areCodesDuplicateShouldReturnFalseWhenCodeIsDuplicate10SecondsAgo() {
+        String barcodeResult = "98238";
+        HashMap<String, Long> alreadyReadCodes = ReflectionHelpers.getField(qrCodeScanningFragment, "alreadyReadCodes");
+        alreadyReadCodes.put(barcodeResult, System.currentTimeMillis() - (10 * 1000));
+
+        SparseArray<Barcode> scanResults = new SparseArray<>();
+
+        Barcode barcode = new Barcode();
+        barcode.rawValue = barcodeResult;
+        scanResults.append(0 , barcode);
+
+        Assert.assertFalse(qrCodeScanningFragment.areCodesDuplicate(scanResults));
+    }
+}


### PR DESCRIPTION
…ecord

- Prevent the same code being scanned within 5 seconds. This fixes an issue where the duplicate QR code causes a connection lost error
on 2 p2p devices. This happens because the detection is not stopped fast enough OR the user is still holding the device in place